### PR TITLE
Improve post preview tooltip

### DIFF
--- a/packages/lesswrong/components/posts/PostsPreviewTooltip.tsx
+++ b/packages/lesswrong/components/posts/PostsPreviewTooltip.tsx
@@ -44,8 +44,9 @@ const styles = (theme: ThemeType): JssStyles => ({
   root: {
     width: POST_PREVIEW_WIDTH,
     position: "relative",
-    padding: theme.spacing.unit*1.5,
-    paddingBottom: 0,
+    padding: theme.spacing.unit*2,
+    paddingBottom: theme.spacing.unit*0.75,
+    borderRadius: 3,
     '& img': {
       maxHeight: "200px"
     },


### PR DESCRIPTION
Lightly increase padding and border radius. The new border radius is consistent with article cards under Recent Discussion.

Before:
<img width="428" alt="Screen Shot 2022-04-18 at 7 33 23 PM" src="https://user-images.githubusercontent.com/11878478/163910013-e1276437-4252-4e71-8ab9-25d17b6ffd72.png">

After:
<img width="428" alt="Screen Shot 2022-04-18 at 7 33 51 PM" src="https://user-images.githubusercontent.com/11878478/163910023-40d626b1-484b-4fb9-81e5-a88d18ac0548.png">

